### PR TITLE
Add ability to output particles to file

### DIFF
--- a/src/include/space.h
+++ b/src/include/space.h
@@ -4,6 +4,7 @@
 #include "p_cats.h"
 #include "particle.h"
 #include <vector>
+#include <fstream>
 
 class Particle;
 
@@ -18,6 +19,8 @@ public:
     Points getCentreOfCharge() override;
     std::vector<Node *> children;
     std::vector<Node *> getChildren() override;
+
+    std::vector<Particle *> getAllParticles();
 
     /// @brief Constructor for Space.
     /// @param minPoint minimum point of the space.
@@ -55,6 +58,11 @@ public:
 
     /// @brief Function to convert the space to a string.
     std::string toString(std::string indent = "");
+
+    /// @brief Function to outpout the space to a file.
+    /// @param path Path to the file.
+    /// @param mode Mode to open the file in. Defaults to std::ios_base::app (append).
+    void toFile(int timeStep, std::string path, std::ios_base::openmode mode = std::ios_base::app);
 };
 
 #endif

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
+#include <fstream>
 
 #define o1 0 // top left back
 #define o2 1 // top right back
@@ -29,6 +30,28 @@ Points Space::getCentreOfCharge()
 std::vector<Node *> Space::getChildren()
 {
     return children;
+}
+
+std::vector<Particle *> Space::getAllParticles()
+{
+    std::vector<Particle *> particles;
+
+    for (auto child : children)
+    {
+        if (dynamic_cast<Particle *>(child))
+        {
+            Particle *particle = dynamic_cast<Particle *>(child);
+            particles.push_back(particle);
+        }
+        else if (dynamic_cast<Space *>(child))
+        {
+            Space *space = dynamic_cast<Space *>(child);
+            std::vector<Particle *> childParticles = space->getAllParticles();
+            particles.insert(particles.end(), childParticles.begin(), childParticles.end());
+        }
+    }
+
+    return particles;
 }
 
 Space::Space(Point minPoint, Point maxPoint, Charge charge) : Node(charge)
@@ -339,4 +362,21 @@ std::string Space::toString(std::string indent)
     }
 
     return out;
+}
+
+void Space::toFile(int timeStep, std::string path, std::ios_base::openmode openMode)
+{
+    std::ofstream file;
+    file.open(path, openMode);
+
+    auto particles = this->getAllParticles();
+    for(auto particle : particles)
+    {
+        file <<
+        timeStep << "," <<
+        particle->alias << "," <<
+        particle->position.x << "," <<
+        particle->position.y << "," <<
+        particle->position.z << ",";
+    }
 }


### PR DESCRIPTION
This pull request adds the ability to output particles to a file. It introduces a new function `toFile` in the `Space` class that takes a time step, a file path, and an optional open mode as parameters. This function opens the file and writes the time step, alias, and position of each particle in the space. This feature will be useful for saving particle data for further analysis or visualization.